### PR TITLE
v1.82.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.76.0" %}
+{% set version = "1.82.0" %}
 
 package:
   name: 'rust-suite'
@@ -6,20 +6,20 @@ package:
 
 source:
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux64]
-    sha256: 9d589d2036b503cc45ecc94992d616fb3deec074deb36cacc2f5c212408f7399  # [linux64]
+    sha256: 0265c08ae997c4de965048a244605fb1f24a600bbe35047b811c638b8fcf676b  # [linux64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
-    sha256: 2e8313421e8fb673efdf356cdfdd4bc16516f2610d4f6faa01327983104c05a0  # [aarch64]
+    sha256: d7db04fce65b5f73282941f3f1df5893be9810af17eb7c65b2e614461fe31a48  # [aarch64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-s390x-unknown-linux-gnu.tar.gz  # [s390x]
-    sha256: 885152d9df8a1db017a2eba315d9f6742b64d638416c1c8b7b5ed5f7cab4b7f4  # [s390x]
+    sha256: 63760886a9b2de6cb38f75a236db358939d904e205e1e2bc9d96cec69e00ae83  # [s390x]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-apple-darwin.tar.gz  # [osx and x86_64]
-    sha256: 7bdbe085695df8e46389115e99eda7beed37a9494f6b961b45554c658e53b8e7  # [osx and x86_64]
+    sha256: b1a289cabc523f259f65116a41374ac159d72fbbf6c373bd5e545c8e835ceb6a  # [osx and x86_64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
-    sha256: 17496f15c3cb6ff73d5c36f5b54cc110f1ac31fa09521a7991c0d7ddd890dceb  # [osx and arm64]
+    sha256: 49b6d36b308addcfd21ae56c94957688338ba7b8985bff57fc626c8e1b32f62c  # [osx and arm64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win64]
-    sha256: cc908e1f0625aae0da5f4a35c390828947887929af694029fc3ccdf4cc66b0dd  # [win64]
+    sha256: b5fac89899343fbc1b8438ff87b77cddaed90a75873db7b01f2c197a26ec9d52  # [win64]
     folder: msvc  # [win64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-gnu.tar.gz  # [win64]
-    sha256: 5a9722e73b4511d41cc70270a730f233da43c8c2e103ae469c3b62d89e78df35  # [win64]
+    sha256: 23149a74246f2a50b6ff5d5c2ec3a1a65634bc207ab1267427e9c7ad6830374d  # [win64]
     folder: gnu  # [win64]
 
 build:
@@ -71,6 +71,7 @@ outputs:
         - '**/libz.so.1'
         # Since 1.32.0 linux also needs:
         - '**/libstdc++.so.6'
+        - '*/api-ms-win-core-winrt-l1-1-0.dll'  # [win]
     requirements:
       build:
         - {{ compiler('c') }}    # [osx]


### PR DESCRIPTION
rust v1.82.0

**Destination channel:** defaults

### Links

- [PKG-5832](https://anaconda.atlassian.net/browse/PKG-5832) 
- [Upstream repository](https://github.com/rust-lang/rust/tree/1.82.0)
- [Upstream changelog/diff](https://github.com/rust-lang/rust/releases)
- Relevant PRs:
  - https://github.com/AnacondaRecipes/rust-activation-feedstock/pull/9
  - https://github.com/AnacondaRecipes/pydantic-core-feedstock/pull/6
  - https://github.com/AnacondaRecipes/cryptography-feedstock/pull/35

### Explanation of changes:

- Bump version and SHAs

### Notes

- See above relevant PRs to verify packages can be built with this compiler.
- This fixes a CVE on Windows for anything compiled with <1.81.0, Those packages will need to be re-built once this is released. 


[PKG-5832]: https://anaconda.atlassian.net/browse/PKG-5832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ