### PR TITLE
[skip CI] rebuild rust 1.82.0 for wasm-wasip* and arch-specific toolchains

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,3 @@
-rust_arch:
-  - x86_64-unknown-linux-gnu       # [linux64]
-  - s390x-unknown-linux-gnu        # [s390x]
-  - aarch64-unknown-linux-gnu      # [aarch64]
-  - x86_64-apple-darwin            # [osx and x86_64]
-  - aarch64-apple-darwin           # [osx and arm64]
-  - x86_64-pc-windows-msvc         # [win]
 rust_std_extra:
   - wasm32-wasip1
   - wasm32-wasip2

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,6 +4,9 @@ rust_arch:
   - aarch64-unknown-linux-gnu      # [aarch64]
   - x86_64-apple-darwin            # [osx and x86_64]
   - aarch64-apple-darwin           # [osx and arm64]
+rust_std_extra:
+  - wasm32-wasip1
+  - wasm32-wasip2
 macos_min_version:
   - 10.12 # [osx and x86_64]
 MACOSX_DEPLOYMENT_TARGET:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,6 +4,7 @@ rust_arch:
   - aarch64-unknown-linux-gnu      # [aarch64]
   - x86_64-apple-darwin            # [osx and x86_64]
   - aarch64-apple-darwin           # [osx and arm64]
+  - x86_64-pc-windows-msvc         # [win]
 rust_std_extra:
   - wasm32-wasip1
   - wasm32-wasip2

--- a/recipe/install-rust-std-extra.sh
+++ b/recipe/install-rust-std-extra.sh
@@ -2,8 +2,8 @@
 
 cd rust-std-${rust_std_extra} && ./install.sh --prefix="${PREFIX}"
 
-rm $PREFIX/lib/rustlib/manifest-rust-std-${rust_std_extra}
-rm $PREFIX/lib/rustlib/rust-installer-version
-rm $PREFIX/lib/rustlib/install.log
-rm $PREFIX/lib/rustlib/components
-rm $PREFIX/lib/rustlib/uninstall.sh
+rm -f $PREFIX/lib/rustlib/manifest-rust-std-${rust_std_extra}
+rm -f $PREFIX/lib/rustlib/rust-installer-version
+rm -f $PREFIX/lib/rustlib/install.log
+rm -f $PREFIX/lib/rustlib/components
+rm -f $PREFIX/lib/rustlib/uninstall.sh

--- a/recipe/install-rust-std-extra.sh
+++ b/recipe/install-rust-std-extra.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+cd rust-std-${rust_std_extra} && ./install.sh --prefix="${PREFIX}"
+
+rm $PREFIX/lib/rustlib/manifest-rust-std-${rust_std_extra}
+rm $PREFIX/lib/rustlib/rust-installer-version
+rm $PREFIX/lib/rustlib/install.log
+rm $PREFIX/lib/rustlib/components
+rm $PREFIX/lib/rustlib/uninstall.sh

--- a/recipe/install-rust-std.sh
+++ b/recipe/install-rust-std.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+cd rust-std && ./install.sh --prefix="${PREFIX}"
+
+rm $PREFIX/lib/rustlib/manifest-rust-std-${rust_arch}
+rm $PREFIX/lib/rustlib/rust-installer-version
+rm $PREFIX/lib/rustlib/install.log
+rm $PREFIX/lib/rustlib/components
+rm $PREFIX/lib/rustlib/uninstall.sh

--- a/recipe/install-rust-std.sh
+++ b/recipe/install-rust-std.sh
@@ -2,8 +2,8 @@
 
 cd rust-std && ./install.sh --prefix="${PREFIX}"
 
-rm $PREFIX/lib/rustlib/manifest-rust-std-${rust_arch}
-rm $PREFIX/lib/rustlib/rust-installer-version
-rm $PREFIX/lib/rustlib/install.log
-rm $PREFIX/lib/rustlib/components
-rm $PREFIX/lib/rustlib/uninstall.sh
+rm -f $PREFIX/lib/rustlib/manifest-rust-std-${rust_arch}
+rm -f $PREFIX/lib/rustlib/rust-installer-version
+rm -f $PREFIX/lib/rustlib/install.log
+rm -f $PREFIX/lib/rustlib/components
+rm -f $PREFIX/lib/rustlib/uninstall.sh

--- a/recipe/install-unix.sh
+++ b/recipe/install-unix.sh
@@ -7,5 +7,23 @@ PATH="${PWD}:$PATH" ./install.sh --prefix="${PREFIX}"
 
 [[ `uname` == Darwin ]] && DSO_EXT='dylib' || DSO_EXT='so'
 
+case "$(uname -sp)" in
+"Linux aarch64")
+    rust_arch="aarch64-unknown-linux-gnu"
+    ;;
+"Linux x86_64")
+    rust_arch="x86_64-unknown-linux-gnu"
+    ;;
+"Darwin i386")
+    rust_arch="x86_64-apple-darwin"
+    ;;
+"Darwin arm")
+    rust_arch="aarch64-apple-darwin"
+    ;;
+*)
+    rust_arch=""
+    ;;
+esac
+
 # these files appear to be missing from the rustlib dir
 ln -s ${PREFIX}/lib/librustc_driver-*.${DSO_EXT} ${PREFIX}/lib/rustlib/${rust_arch}/lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -162,6 +162,7 @@ outputs:
 
   - name: rust-std-{{ rust_std_extra }}
     build:
+      noarch: generic
       binary_relocation: False
       runpath_whitelist:
         - $ORIGIN/../lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,6 +5,7 @@ package:
   version: {{ version }}
 
 source:
+    #### start of main rust toolchain sources
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux64]
     sha256: 0265c08ae997c4de965048a244605fb1f24a600bbe35047b811c638b8fcf676b  # [linux64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
@@ -15,12 +16,26 @@ source:
     sha256: b1a289cabc523f259f65116a41374ac159d72fbbf6c373bd5e545c8e835ceb6a  # [osx and x86_64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
     sha256: 49b6d36b308addcfd21ae56c94957688338ba7b8985bff57fc626c8e1b32f62c  # [osx and arm64]
-  - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win64]
-    sha256: b5fac89899343fbc1b8438ff87b77cddaed90a75873db7b01f2c197a26ec9d52  # [win64]
-    folder: msvc  # [win64]
+  - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
+    sha256: b5fac89899343fbc1b8438ff87b77cddaed90a75873db7b01f2c197a26ec9d52  # [win]
+    folder: msvc  # [win]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-gnu.tar.gz  # [win64]
     sha256: 23149a74246f2a50b6ff5d5c2ec3a1a65634bc207ab1267427e9c7ad6830374d  # [win64]
-    folder: gnu  # [win64]
+    folder: gnu  # [win]
+    #### end of main rust toolchain sources
+    #### start of rust-std toolchain sources
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
+    sha256: e7e808b8745298369fa3bbc3c0b7af9ca0fb995661bd684a7022d14bc9ae0057  # [linux and x86_64]
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [linux and aarch64]
+    sha256: 82b2308ee531775bf4d1faa57bddfae85f363bec43ca36ba6db4ebad7c1450d4  # [linux and aarch64]
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-apple-darwin.tar.gz  # [osx and x86_64]
+    sha256: 52084c8cdb34ca139a00f9f03f1a582d96b677e9f223a8d1aa31ae575a06cc16  # [osx and x86_64]
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
+    sha256: 5ec28e75ed8715efaa2490d76ae026a34b13df6899d98b14d0a6995556f4e6b4  # [osx and arm64]
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
+    sha256: afe8fbf37001f559cbddc7c786db50946d3f483f12a290115ee1ef8fff10a833  # [win]
+    folder: msvc  # [win]
+    #### end of rust-std toolchain sources
 
 build:
   number: 0
@@ -105,6 +120,24 @@ outputs:
         - rustc --help  # [win]
         - rustdoc --help  # [win]
         - if exist %LIBRARY_PREFIX%\share\doc\rust\html\sysroot exit 1  # [win]
+
+  - name: rust-std-{{ rust_arch }}
+    build:
+      noarch: generic
+      binary_relocation: False
+    requirements:
+      build:
+        - posix  # [win]
+      host:
+      run:
+      run_constrained:
+        # Having different versions of rust-std and rust is confusing.
+        - {{ pin_subpackage("rust", min_pin="x.x.x", max_pin="x.x.x") }}
+    script: ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: install-msvc.bat  # [win]
+    test:
+      commands:
+        - test -d $PREFIX/lib/rustlib
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,13 +136,13 @@ outputs:
   - name: rust-std-{{ rust_arch }}
     build:
       binary_relocation: False
-    script: cd rust-std-=- && ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: cd rust-std && ./install.sh --prefix="${PREFIX}"  # [unix]
     script: install-msvc.bat  # [win]
     requirements:
       build:
         - posix  # [win]
       run:
-        - {{ pin_subpackage("rust", exact=True") }}
+        - {{ pin_subpackage("rust", exact=True) }}
     test:
       commands:
         - test -d $PREFIX/lib/rustlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,11 +128,8 @@ outputs:
     requirements:
       build:
         - posix  # [win]
-      host:
       run:
-      run_constrained:
-        # Having different versions of rust-std and rust is confusing.
-        - {{ pin_subpackage("rust", min_pin="x.x.x", max_pin="x.x.x") }}
+        - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
     script: ./install.sh --prefix="${PREFIX}"  # [unix]
     script: install-msvc.bat  # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,14 @@ source:
     sha256: afe8fbf37001f559cbddc7c786db50946d3f483f12a290115ee1ef8fff10a833  # [win]
     folder: rust-std  # [win]
     #### end of rust-std toolchain sources
+    #### start of rust-std-extra toolchain sources
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip1.gz
+    sha256: 41cce791e0b2e27838f9ef09707605bb2d4571293fc0e157cd260a0adc90a628
+    folder: rust-std-{{ rust_std_extra }}
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip2.gz
+    sha256: 41cce791e0b2e27838f9ef09707605bb2d4571293fc0e157cd260a0adc90a628
+    folder: rust-std-{{ rust_std_extra }}
+    #### end of rust-std-extra toolchain sources
 
 build:
   number: 0
@@ -138,6 +146,23 @@ outputs:
     test:
       commands:
         - test -d $PREFIX/lib/rustlib
+
+  - name: rust-std-{{ rust_std_extra }}
+    script: cd rust-std-{{ rust_std_extra }} && ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: install-msvc.bat  # [win]
+    requirements:
+      build:
+        - posix  # [win]
+      run:
+        # Having different versions of rust-std and rust is confusing.
+        - {{ pin_subpackage("rust-std", min_pin="x.x.x", max_pin="x.x.x") }}
+    test:
+      commands:
+        - test -d $PREFIX/lib/rustlib/{{ rust_std_extra }}  # [unix]
+        - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}" exit 1  # [win]
+        # Make sure that the outputs do not clobber with other rust components
+        - test -z "$(ls "${PREFIX}"/lib/rustlib/ | grep -v {{ rust_std_extra }})"  # [unix]
+        - dir /b "%LIBRARY_PREFIX%" | findstr /v "{{ rust_std_extra }}" >nul || exit 1  # [win]
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,15 +127,14 @@ outputs:
 
   - name: rust-std-{{ rust_arch }}
     build:
-      noarch: generic
       binary_relocation: False
+    script: cd rust-std-=- && ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: install-msvc.bat  # [win]
     requirements:
       build:
         - posix  # [win]
       run:
         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
-    script: cd rust-std && ./install.sh --prefix="${PREFIX}"  # [unix]
-    script: install-msvc.bat  # [win]
     test:
       commands:
         - test -d $PREFIX/lib/rustlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -173,13 +173,14 @@ outputs:
         - "/lib64/libdl.so.*"
         - "/lib64/libc.so.*"
         - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
+      run_exports:
+        strong:
+          - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:
       build:
         - posix  # [win]
-      run:
-        - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
     test:
       commands:
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -139,10 +139,12 @@ outputs:
       runpath_whitelist:
         - $ORIGIN/../lib
       missing_dso_whitelist:
-        - '/**/libgcc_s.so.*'
-        - '/**/libpthread.so.*'
-        - '/**/libdl.so.*'
-        - '/**/libc.so.*'
+        - "/lib64/libgcc_s.so.*"
+        - "/lib64/librt.so.*"
+        - "/lib64/libpthread.so.*"
+        - "/lib64/libdl.so.*"
+        - "/lib64/libc.so.*"
+        - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
     script: install-rust-std.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:
@@ -164,12 +166,12 @@ outputs:
       runpath_whitelist:
         - $ORIGIN/../lib
       missing_dso_whitelist:
-        - '/**/libgcc_s.so.*'
-        - '/**/librt.so.*'
-        - '/**/libpthread.so.*'
-        - '/**/libdl.so.*'
-        - '/**/libc.so.*'
-        - '/**/ld-linux-x86-64.so.*'
+        - "/lib64/libgcc_s.so.*"
+        - "/lib64/librt.so.*"
+        - "/lib64/libpthread.so.*"
+        - "/lib64/libdl.so.*"
+        - "/lib64/libc.so.*"
+        - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
     script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,10 +141,10 @@ outputs:
       commands:
         - echo ON  # [win]
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib  # [unix]
-        - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib" exit /B 1  # [win]
+        #- if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib" exit /B 1  # [win]
         # Make sure that the outputs do not clobber with other rust components
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a  # [unix]
-        - if not test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a" exit /B 1  # [win]
+        #- if not test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a" exit /B 1  # [win]
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,7 +136,7 @@ outputs:
   - name: rust-std-{{ rust_arch }}
     build:
       binary_relocation: False
-    script: cd rust-std && ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: install-rust-std.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:
       build:
@@ -148,7 +148,7 @@ outputs:
         - test -d $PREFIX/lib/rustlib
 
   - name: rust-std-{{ rust_std_extra }}
-    script: cd rust-std-{{ rust_std_extra }} && ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:
       build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -187,6 +187,11 @@ outputs:
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a  # [unix]
         - if not test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a" exit /B 1  # [win]
 
+  - name: rust-std-host
+    requirements:
+      run:
+        - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
+
 about:
   home: https://www.rust-lang.org
   license: MIT AND Apache-2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -139,6 +139,7 @@ outputs:
         - posix  # [win]
     test:
       commands:
+        - echo ON  # [win]
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib  # [unix]
         - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib" exit /B 1  # [win]
         # Make sure that the outputs do not clobber with other rust components

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ source:
     sha256: 5ec28e75ed8715efaa2490d76ae026a34b13df6899d98b14d0a6995556f4e6b4  # [osx and arm64]
     folder: rust-std  # [osx and arm64]
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
-    sha256: afe8fbf37001f559cbddc7c786db50946d3f483f12a290115ee1ef8fff10a833  # [win]
+    sha256: e579f3ac4c546e68b4decffa64f2e9a98fe32a373fd5cc89b0449ca57528b1b8  # [win]
     folder: rust-std  # [win]
     #### end of rust-std toolchain sources
     #### start of rust-std-extra toolchain sources

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,12 +41,12 @@ source:
     folder: rust-std  # [win]
     #### end of rust-std toolchain sources
     #### start of rust-std-extra toolchain sources
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip1.gz
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip1.tar.gz
     sha256: 41cce791e0b2e27838f9ef09707605bb2d4571293fc0e157cd260a0adc90a628
-    folder: rust-std-{{ rust_std_extra }}
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip2.gz
-    sha256: 41cce791e0b2e27838f9ef09707605bb2d4571293fc0e157cd260a0adc90a628
-    folder: rust-std-{{ rust_std_extra }}
+    folder: rust-std-wasm32-wasip1
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip2.tar.gz
+    sha256: 5ee71ee1909e1bd960977b3f2c0bc25e77aae5c447bbc6802a19495f7f30538f
+    folder: rust-std-wasm32-wasip2
     #### end of rust-std-extra toolchain sources
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -145,7 +145,11 @@ outputs:
         - {{ pin_subpackage("rust", exact=True) }}
     test:
       commands:
-        - test -d $PREFIX/lib/rustlib
+        - test -f $PREFIX/lib/rustlib/{{ rust_arch }}/lib/libcore*.rlib  # [unix]
+        - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_arch }}/lib/libcore*.rlib" exit /B 1  # [win]
+        # Make sure that the outputs do not clobber with other rust components
+        - test ! -f $PREFIX/lib/rustlib/{{ rust_arch }}/lib/self-contained/libc.a  # [unix]
+        - if test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_arch }}/lib/self-contained/libc.a" exit /B 1  # [win]
 
   - name: rust-std-{{ rust_std_extra }}
     script: install-rust-std-extra.sh  # [unix]
@@ -157,11 +161,11 @@ outputs:
         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
     test:
       commands:
-        - test -d $PREFIX/lib/rustlib/{{ rust_std_extra }}  # [unix]
-        - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}" exit 1  # [win]
+        - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib  # [unix]
+        - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib" exit /B 1  # [win]
         # Make sure that the outputs do not clobber with other rust components
-        - test -z "$(ls "${PREFIX}"/lib/rustlib/ | grep -v {{ rust_std_extra }})"  # [unix]
-        - dir /b "%LIBRARY_PREFIX%" | findstr /v "{{ rust_std_extra }}" >nul || exit 1  # [win]
+        - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a  # [unix]
+        - if not test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a" exit /B 1  # [win]
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     #### end of rust-std-extra toolchain sources
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: rust

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,10 +141,11 @@ outputs:
       commands:
         - echo ON  # [win]
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib  # [unix]
-        #- if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_std_extra }}/lib/libcore*.rlib" exit /B 1  # [win]
         # Make sure that the outputs do not clobber with other rust components
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a  # [unix]
-        #- if not test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a" exit /B 1  # [win]
+        - rustc --print target-list | grep {{ rust_std_extra }}  # [unix]
+      requires:
+        - {{ pin_subpackage('rust', exact=True) }}  # [unix]
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,15 +26,19 @@ source:
     #### start of rust-std toolchain sources
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
     sha256: e7e808b8745298369fa3bbc3c0b7af9ca0fb995661bd684a7022d14bc9ae0057  # [linux and x86_64]
+    folder: rust-std  # [linux and x86_64]
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [linux and aarch64]
     sha256: 82b2308ee531775bf4d1faa57bddfae85f363bec43ca36ba6db4ebad7c1450d4  # [linux and aarch64]
+    folder: rust-std  # [linux and aarch64]
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-apple-darwin.tar.gz  # [osx and x86_64]
     sha256: 52084c8cdb34ca139a00f9f03f1a582d96b677e9f223a8d1aa31ae575a06cc16  # [osx and x86_64]
+    folder: rust-std  # [osx and x86_64]
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
     sha256: 5ec28e75ed8715efaa2490d76ae026a34b13df6899d98b14d0a6995556f4e6b4  # [osx and arm64]
+    folder: rust-std  # [osx and arm64]
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
     sha256: afe8fbf37001f559cbddc7c786db50946d3f483f12a290115ee1ef8fff10a833  # [win]
-    folder: msvc  # [win]
+    folder: rust-std  # [win]
     #### end of rust-std toolchain sources
 
 build:
@@ -130,7 +134,7 @@ outputs:
         - posix  # [win]
       run:
         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
-    script: ./install.sh --prefix="${PREFIX}"  # [unix]
+    script: cd rust-std && ./install.sh --prefix="${PREFIX}"  # [unix]
     script: install-msvc.bat  # [win]
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -142,7 +142,7 @@ outputs:
       build:
         - posix  # [win]
       run:
-        - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
+        - {{ pin_subpackage("rust", exact=True") }}
     test:
       commands:
         - test -d $PREFIX/lib/rustlib
@@ -154,8 +154,7 @@ outputs:
       build:
         - posix  # [win]
       run:
-        # Having different versions of rust-std and rust is confusing.
-        - {{ pin_subpackage("rust-std", min_pin="x.x.x", max_pin="x.x.x") }}
+        - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
     test:
       commands:
         - test -d $PREFIX/lib/rustlib/{{ rust_std_extra }}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,23 +23,6 @@ source:
     sha256: 23149a74246f2a50b6ff5d5c2ec3a1a65634bc207ab1267427e9c7ad6830374d  # [win64]
     folder: gnu  # [win]
     #### end of main rust toolchain sources
-    #### start of rust-std toolchain sources
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
-    sha256: e7e808b8745298369fa3bbc3c0b7af9ca0fb995661bd684a7022d14bc9ae0057  # [linux and x86_64]
-    folder: rust-std  # [linux and x86_64]
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [linux and aarch64]
-    sha256: 82b2308ee531775bf4d1faa57bddfae85f363bec43ca36ba6db4ebad7c1450d4  # [linux and aarch64]
-    folder: rust-std  # [linux and aarch64]
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-apple-darwin.tar.gz  # [osx and x86_64]
-    sha256: 52084c8cdb34ca139a00f9f03f1a582d96b677e9f223a8d1aa31ae575a06cc16  # [osx and x86_64]
-    folder: rust-std  # [osx and x86_64]
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
-    sha256: 5ec28e75ed8715efaa2490d76ae026a34b13df6899d98b14d0a6995556f4e6b4  # [osx and arm64]
-    folder: rust-std  # [osx and arm64]
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
-    sha256: e579f3ac4c546e68b4decffa64f2e9a98fe32a373fd5cc89b0449ca57528b1b8  # [win]
-    folder: rust-std  # [win]
-    #### end of rust-std toolchain sources
     #### start of rust-std-extra toolchain sources
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip1.tar.gz
     sha256: 41cce791e0b2e27838f9ef09707605bb2d4571293fc0e157cd260a0adc90a628
@@ -133,33 +116,6 @@ outputs:
         - rustdoc --help  # [win]
         - if exist %LIBRARY_PREFIX%\share\doc\rust\html\sysroot exit 1  # [win]
 
-  - name: rust-std-{{ rust_arch }}
-    build:
-      binary_relocation: False
-      runpath_whitelist:
-        - $ORIGIN/../lib
-      missing_dso_whitelist:
-        - "/lib64/libgcc_s.so.*"
-        - "/lib64/librt.so.*"
-        - "/lib64/libpthread.so.*"
-        - "/lib64/libdl.so.*"
-        - "/lib64/libc.so.*"
-        - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
-    script: install-rust-std.sh  # [unix]
-    script: install-msvc.bat  # [win]
-    requirements:
-      build:
-        - posix  # [win]
-      run:
-        - {{ pin_subpackage("rust", exact=True) }}
-    test:
-      commands:
-        - test -f $PREFIX/lib/rustlib/{{ rust_arch }}/lib/libcore*.rlib  # [unix]
-        - if not exist "%LIBRARY_PREFIX%/lib/rustlib/{{ rust_arch }}/lib/libcore*.rlib" exit /B 1  # [win]
-        # Make sure that the outputs do not clobber with other rust components
-        - test ! -f $PREFIX/lib/rustlib/{{ rust_arch }}/lib/self-contained/libc.a  # [unix]
-        - if test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_arch }}/lib/self-contained/libc.a" exit /B 1  # [win]
-
   - name: rust-std-{{ rust_std_extra }}
     build:
       noarch: generic
@@ -188,11 +144,6 @@ outputs:
         # Make sure that the outputs do not clobber with other rust components
         - test -f $PREFIX/lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a  # [unix]
         - if not test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_std_extra }}/lib/self-contained/libc.a" exit /B 1  # [win]
-
-  - name: rust-std-host
-    requirements:
-      run:
-        - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,6 +136,13 @@ outputs:
   - name: rust-std-{{ rust_arch }}
     build:
       binary_relocation: False
+      runpath_whitelist:
+        - $ORIGIN/../lib
+      missing_dso_whitelist:
+        - '/**/libgcc_s.so.*'
+        - '/**/libpthread.so.*'
+        - '/**/libdl.so.*'
+        - '/**/libc.so.*'
     script: install-rust-std.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:
@@ -152,6 +159,17 @@ outputs:
         - if test "%LIBRARY_PREFIX%//lib/rustlib/{{ rust_arch }}/lib/self-contained/libc.a" exit /B 1  # [win]
 
   - name: rust-std-{{ rust_std_extra }}
+    build:
+      binary_relocation: False
+      runpath_whitelist:
+        - $ORIGIN/../lib
+      missing_dso_whitelist:
+        - '/**/libgcc_s.so.*'
+        - '/**/librt.so.*'
+        - '/**/libpthread.so.*'
+        - '/**/libdl.so.*'
+        - '/**/libc.so.*'
+        - '/**/ld-linux-x86-64.so.*'
     script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:


### PR DESCRIPTION
rust 1.82.0

**Destination channel:** Defaults
### Links

- [PKG-7279]
- dev_url:        https://github.com/rust-lang/rust/tree/1.82.0
- conda_forge:    https://github.com/conda-forge/rust-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- rebuild to include arch-specific, `wasm-wapi1` and `wasm-wapi2` toolchains.


[PKG-6385]: https://anaconda.atlassian.net/browse/PKG-6385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-7279]: https://anaconda.atlassian.net/browse/PKG-7279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ