### PR TITLE
rebuild rust 1.82.0 w/ wasm32-wasip as non-noarch

### DIFF
--- a/recipe/install-rust-std-extra.bat
+++ b/recipe/install-rust-std-extra.bat
@@ -1,6 +1,10 @@
 @echo off
 
-cd rust-std-%rust_std_extra% && call install.bat --prefix="%PREFIX%\Library"
+cd rust-std-%rust_std_extra%
+
+FOR /F "delims=" %%i in ('cygpath.exe -u "%PREFIX%"') DO set "pfx=%%i"
+bash install.sh --prefix=%pfx%/Library
+if errorlevel 1 exit 1
 
 del /f /q %PREFIX%\Library\lib\rustlib\manifest-rust-std-%rust_std_extra%
 del /f /q %PREFIX%\Library\lib\rustlib\rust-installer-version

--- a/recipe/install-rust-std-extra.bat
+++ b/recipe/install-rust-std-extra.bat
@@ -1,0 +1,9 @@
+@echo off
+
+cd rust-std-%rust_std_extra% && call install.bat --prefix="%PREFIX%"
+
+del /f /q %PREFIX%\lib\rustlib\manifest-rust-std-%rust_std_extra%
+del /f /q %PREFIX%\lib\rustlib\rust-installer-version
+del /f /q %PREFIX%\lib\rustlib\install.log
+del /f /q %PREFIX%\lib\rustlib\components
+del /f /q %PREFIX%\lib\rustlib\uninstall.sh

--- a/recipe/install-rust-std-extra.bat
+++ b/recipe/install-rust-std-extra.bat
@@ -1,9 +1,9 @@
 @echo off
 
-cd rust-std-%rust_std_extra% && call install.bat --prefix="%PREFIX%"
+cd rust-std-%rust_std_extra% && call install.bat --prefix="%PREFIX%\Library"
 
-del /f /q %PREFIX%\lib\rustlib\manifest-rust-std-%rust_std_extra%
-del /f /q %PREFIX%\lib\rustlib\rust-installer-version
-del /f /q %PREFIX%\lib\rustlib\install.log
-del /f /q %PREFIX%\lib\rustlib\components
-del /f /q %PREFIX%\lib\rustlib\uninstall.sh
+del /f /q %PREFIX%\Library\lib\rustlib\manifest-rust-std-%rust_std_extra%
+del /f /q %PREFIX%\Library\lib\rustlib\rust-installer-version
+del /f /q %PREFIX%\Library\lib\rustlib\install.log
+del /f /q %PREFIX%\Library\lib\rustlib\components
+del /f /q %PREFIX%\Library\lib\rustlib\uninstall.sh

--- a/recipe/install-rust-std.sh
+++ b/recipe/install-rust-std.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-cd rust-std && ./install.sh --prefix="${PREFIX}"
-
-rm -f $PREFIX/lib/rustlib/manifest-rust-std-${rust_arch}
-rm -f $PREFIX/lib/rustlib/rust-installer-version
-rm -f $PREFIX/lib/rustlib/install.log
-rm -f $PREFIX/lib/rustlib/components
-rm -f $PREFIX/lib/rustlib/uninstall.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     #### end of rust-std-extra toolchain sources
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: rust

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,7 +132,7 @@ outputs:
         strong:
           - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
-    script: install-msvc.bat  # [win]
+    script: install-rust-std-extra.bat  # [win]
     requirements:
       build:
         - posix  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,9 +129,9 @@ outputs:
         - "/lib64/libdl.so.*"
         - "/lib64/libc.so.*"
         - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
-      run_exports:
-        strong:
-          - {{ pin_subpackage("rust", exact=True) }}
+      #run_exports:
+      #  strong:
+      #    - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,7 +118,7 @@ outputs:
 
   - name: rust-std-{{ rust_std_extra }}
     build:
-      noarch: generic
+      #noarch: generic
       binary_relocation: False
       runpath_whitelist:
         - $ORIGIN/../lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,7 +118,6 @@ outputs:
 
   - name: rust-std-{{ rust_std_extra }}
     build:
-      #noarch: generic
       binary_relocation: False
       runpath_whitelist:
         - $ORIGIN/../lib
@@ -129,9 +128,6 @@ outputs:
         - "/lib64/libdl.so.*"
         - "/lib64/libc.so.*"
         - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
-      #run_exports:
-      #  strong:
-      #    - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,6 +128,9 @@ outputs:
         - "/lib64/libdl.so.*"
         - "/lib64/libc.so.*"
         - "/lib64/ld-linux-x86-64.so.*"  # [linux and x86_64]
+      run_exports:
+        strong:
+          - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
     script: install-msvc.bat  # [win]
     requirements:


### PR DESCRIPTION
Building `rust-std-wasm32-wasip<_v-api_> 1.82.0` as `noarch` caused the `target_platform` to be set to `linux-64` in the `info/about.json` inside the package. This results in an unsuccessful pinning of arch-specific `rust` in the `run_export` section.