### PR TITLE
Adapting for 14.3 gcc toolchain

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+task_timeout: 5400

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,1 @@
-task_timeout: 5400
+task_timeout: 10800

--- a/recipe/forge_test.sh
+++ b/recipe/forge_test.sh
@@ -6,7 +6,7 @@ if [[ ${target_platform} =~ linux.*390x.* ]]; then
 elif [[ ${target_platform} =~ linux.*aarch64* ]]; then
   echo "aarch64-conda-linux-gnu-cc \"\$@\""   >> ./cc
 elif [[ ${target_platform} =~ linux.* ]]; then
-  echo "x86_64-conda_cos7-linux-gnu-cc \"\$@\""   >> ./cc
+  echo "x86_64-conda-linux-gnu-cc \"\$@\""   >> ./cc
 elif [[ ${target_platform} == osx-arm64 ]]; then
   echo "arm64-apple-darwin20.0.0-clang \"\$@\""  >> ./cc
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     #### end of rust-std-extra toolchain sources
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: rust


### PR DESCRIPTION
rust 1.89 (rebuild for gcc 14.3 toolchain)

**Destination channel:** defaults

### Links

- [PKG-11606](https://anaconda.atlassian.net/browse/PKG-11606) 
- conda-forge repo: https://github.com/conda-forge/rust-feedstock
- corresponding rust-activation PR: https://github.com/AnacondaRecipes/rust-activation-feedstock/pull/20


### Explanation of changes:

- Rebuilding for gcc 14.3 toolchain.
- changed reference to compiler executable in a test script. The compiler executable was duplicated under two names in previous 11.2 build, but only one name in 14.3 build.



[PKG-11606]: https://anaconda.atlassian.net/browse/PKG-11606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ