### PR TITLE
initial win-arm64 support

### DIFF
--- a/recipe/install-gnu.bat
+++ b/recipe/install-gnu.bat
@@ -1,4 +1,42 @@
-pushd gnu
-FOR /F "delims=" %%i in ('cygpath.exe -u "%PREFIX%"') DO set "pfx=%%i"
-bash install.sh --prefix=%pfx%/Library
-if errorlevel 1 exit 1
+@echo off
+setlocal enabledelayedexpansion
+
+set "DESTDIR=%LIBRARY_PREFIX%"
+set "SRCDIR=%SRC_DIR%\gnu"
+
+echo Installing Rust GNU from %SRCDIR% to %DESTDIR%
+
+REM Read components and install each one
+for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
+    echo Installing component: %%c
+    set "COMPDIR=%SRCDIR%\%%c"
+    
+    REM Copy bin directory if exists
+    if exist "!COMPDIR!\bin" (
+        xcopy /E /I /Y "!COMPDIR!\bin" "%DESTDIR%\bin\"
+    )
+    
+    REM Copy lib directory if exists  
+    if exist "!COMPDIR!\lib" (
+        xcopy /E /I /Y "!COMPDIR!\lib" "%DESTDIR%\lib\"
+    )
+    
+    REM Copy share directory if exists
+    if exist "!COMPDIR!\share" (
+        xcopy /E /I /Y "!COMPDIR!\share" "%DESTDIR%\share\"
+    )
+    
+    REM Copy etc directory if exists
+    if exist "!COMPDIR!\etc" (
+        xcopy /E /I /Y "!COMPDIR!\etc" "%DESTDIR%\etc\"
+    )
+)
+
+REM Remove documentation to reduce package size (docs available online)
+if exist "%DESTDIR%\share\doc" (
+    echo Removing documentation...
+    rmdir /S /Q "%DESTDIR%\share\doc"
+)
+
+echo Rust GNU installation complete.
+exit /b 0

--- a/recipe/install-gnu.bat
+++ b/recipe/install-gnu.bat
@@ -14,26 +14,31 @@ for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
     REM Copy bin directory if exists
     if exist "!COMPDIR!\bin" (
         xcopy /E /I /Y "!COMPDIR!\bin" "%DESTDIR%\bin\"
+        if errorlevel 1 exit /b 1
     )
     
     REM Copy lib directory if exists  
     if exist "!COMPDIR!\lib" (
         xcopy /E /I /Y "!COMPDIR!\lib" "%DESTDIR%\lib\"
+        if errorlevel 1 exit /b 1
     )
     
     REM Copy share directory if exists
     if exist "!COMPDIR!\share" (
         xcopy /E /I /Y "!COMPDIR!\share" "%DESTDIR%\share\"
+        if errorlevel 1 exit /b 1
     )
     
     REM Copy etc directory if exists
     if exist "!COMPDIR!\etc" (
         xcopy /E /I /Y "!COMPDIR!\etc" "%DESTDIR%\etc\"
+        if errorlevel 1 exit /b 1
     )
 
     REM Copy libexec directory if exists
     if exist "!COMPDIR!\libexec" (
         xcopy /E /I /Y "!COMPDIR!\libexec" "%DESTDIR%\libexec\"
+        if errorlevel 1 exit /b 1
     )
 )
 

--- a/recipe/install-gnu.bat
+++ b/recipe/install-gnu.bat
@@ -30,6 +30,11 @@ for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
     if exist "!COMPDIR!\etc" (
         xcopy /E /I /Y "!COMPDIR!\etc" "%DESTDIR%\etc\"
     )
+
+    REM Copy libexec directory if exists
+    if exist "!COMPDIR!\libexec" (
+        xcopy /E /I /Y "!COMPDIR!\libexec" "%DESTDIR%\libexec\"
+    )
 )
 
 REM Remove documentation to reduce package size (docs available online)

--- a/recipe/install-msvc.bat
+++ b/recipe/install-msvc.bat
@@ -1,4 +1,42 @@
-pushd msvc
-FOR /F "delims=" %%i in ('cygpath.exe -u "%PREFIX%"') DO set "pfx=%%i"
-bash install.sh --prefix=%pfx%/Library
-if errorlevel 1 exit 1
+@echo off
+setlocal enabledelayedexpansion
+
+set "DESTDIR=%LIBRARY_PREFIX%"
+set "SRCDIR=%SRC_DIR%\msvc"
+
+echo Installing Rust from %SRCDIR% to %DESTDIR%
+
+REM Read components and install each one
+for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
+    echo Installing component: %%c
+    set "COMPDIR=%SRCDIR%\%%c"
+    
+    REM Copy bin directory if exists
+    if exist "!COMPDIR!\bin" (
+        xcopy /E /I /Y "!COMPDIR!\bin" "%DESTDIR%\bin\"
+    )
+    
+    REM Copy lib directory if exists  
+    if exist "!COMPDIR!\lib" (
+        xcopy /E /I /Y "!COMPDIR!\lib" "%DESTDIR%\lib\"
+    )
+    
+    REM Copy share directory if exists
+    if exist "!COMPDIR!\share" (
+        xcopy /E /I /Y "!COMPDIR!\share" "%DESTDIR%\share\"
+    )
+    
+    REM Copy etc directory if exists
+    if exist "!COMPDIR!\etc" (
+        xcopy /E /I /Y "!COMPDIR!\etc" "%DESTDIR%\etc\"
+    )
+)
+
+REM Remove documentation to reduce package size (docs available online)
+if exist "%DESTDIR%\share\doc" (
+    echo Removing documentation...
+    rmdir /S /Q "%DESTDIR%\share\doc"
+)
+
+echo Rust installation complete.
+exit /b 0

--- a/recipe/install-msvc.bat
+++ b/recipe/install-msvc.bat
@@ -14,26 +14,31 @@ for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
     REM Copy bin directory if exists
     if exist "!COMPDIR!\bin" (
         xcopy /E /I /Y "!COMPDIR!\bin" "%DESTDIR%\bin\"
+        if errorlevel 1 exit /b 1
     )
     
     REM Copy lib directory if exists  
     if exist "!COMPDIR!\lib" (
         xcopy /E /I /Y "!COMPDIR!\lib" "%DESTDIR%\lib\"
+        if errorlevel 1 exit /b 1
     )
     
     REM Copy share directory if exists
     if exist "!COMPDIR!\share" (
         xcopy /E /I /Y "!COMPDIR!\share" "%DESTDIR%\share\"
+        if errorlevel 1 exit /b 1
     )
     
     REM Copy etc directory if exists
     if exist "!COMPDIR!\etc" (
         xcopy /E /I /Y "!COMPDIR!\etc" "%DESTDIR%\etc\"
+        if errorlevel 1 exit /b 1
     )
 
     REM Copy libexec directory if exists
     if exist "!COMPDIR!\libexec" (
         xcopy /E /I /Y "!COMPDIR!\libexec" "%DESTDIR%\libexec\"
+        if errorlevel 1 exit /b 1
     )
 )
 

--- a/recipe/install-msvc.bat
+++ b/recipe/install-msvc.bat
@@ -30,6 +30,11 @@ for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
     if exist "!COMPDIR!\etc" (
         xcopy /E /I /Y "!COMPDIR!\etc" "%DESTDIR%\etc\"
     )
+
+    REM Copy libexec directory if exists
+    if exist "!COMPDIR!\libexec" (
+        xcopy /E /I /Y "!COMPDIR!\libexec" "%DESTDIR%\libexec\"
+    )
 )
 
 REM Remove documentation to reduce package size (docs available online)

--- a/recipe/install-rust-std-extra.bat
+++ b/recipe/install-rust-std-extra.bat
@@ -1,13 +1,28 @@
 @echo off
+setlocal enabledelayedexpansion
 
-cd rust-std-%rust_std_extra%
+set "DESTDIR=%LIBRARY_PREFIX%"
+set "SRCDIR=%SRC_DIR%\rust-std-%rust_std_extra%"
 
-FOR /F "delims=" %%i in ('cygpath.exe -u "%PREFIX%"') DO set "pfx=%%i"
-bash install.sh --prefix=%pfx%/Library
-if errorlevel 1 exit 1
+echo Installing rust-std-%rust_std_extra% from %SRCDIR% to %DESTDIR%
 
-del /f /q %PREFIX%\Library\lib\rustlib\manifest-rust-std-%rust_std_extra%
-del /f /q %PREFIX%\Library\lib\rustlib\rust-installer-version
-del /f /q %PREFIX%\Library\lib\rustlib\install.log
-del /f /q %PREFIX%\Library\lib\rustlib\components
-del /f /q %PREFIX%\Library\lib\rustlib\uninstall.sh
+REM Read components and install each one
+for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
+    echo Installing component: %%c
+    set "COMPDIR=%SRCDIR%\%%c"
+    
+    REM Copy lib directory if exists  
+    if exist "!COMPDIR!\lib" (
+        xcopy /E /I /Y "!COMPDIR!\lib" "%DESTDIR%\lib\"
+    )
+)
+
+REM Clean up installer metadata files
+del /f /q "%DESTDIR%\lib\rustlib\manifest-rust-std-%rust_std_extra%" 2>nul
+del /f /q "%DESTDIR%\lib\rustlib\rust-installer-version" 2>nul
+del /f /q "%DESTDIR%\lib\rustlib\install.log" 2>nul
+del /f /q "%DESTDIR%\lib\rustlib\components" 2>nul
+del /f /q "%DESTDIR%\lib\rustlib\uninstall.sh" 2>nul
+
+echo rust-std-%rust_std_extra% installation complete.
+exit /b 0

--- a/recipe/install-rust-std-extra.bat
+++ b/recipe/install-rust-std-extra.bat
@@ -14,6 +14,7 @@ for /f "usebackq tokens=*" %%c in ("%SRCDIR%\components") do (
     REM Copy lib directory if exists  
     if exist "!COMPDIR!\lib" (
         xcopy /E /I /Y "!COMPDIR!\lib" "%DESTDIR%\lib\"
+        if errorlevel 1 exit /b 1
     )
 )
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # !! update of rust version should be carried out together with rust-activation version update !!
 # https://github.com/AnacondaRecipes/rust-activation-feedstock
-{% set version = "1.89.0" %}
+{% set version = "1.90.0" %}
 
 package:
   name: 'rust-suite'
@@ -9,29 +9,32 @@ package:
 source:
     #### start of main rust toolchain sources
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux64]
-    sha256: 542f517d0624cbee516627221482b166bf0ffe5fd560ec32beb778c01f5c99b6  # [linux64]
+    sha256: e453bae1c68d02fe2eae065c5452d5731308164cd154154c6ee442d2fa590685  # [linux64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
-    sha256: 26d6de84ac59da702aa8c2f903e3c344e3259da02e02ce92ad1c735916b29a4a  # [aarch64]
+    sha256: 293f412e3412c3aa3398c78ebbdf898fa08eacad80c85a7332ce1a455504c5fc  # [aarch64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
-    sha256: 87baeb57fb29339744ac5f99857f0077b12fa463217fc165dfd8f77412f38118  # [osx and arm64]
-  - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
-    sha256: 6f899d4a8e6f3243ce23593897a11c77eef535237522b530148b4cfd56d19219  # [win]
-    folder: msvc  # [win]
+    sha256: a11b52e34f5e80cb25d49f7943ae60e0b069b431727a4c09b2c890ceebee3687  # [osx and arm64]
+  - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win64]
+    sha256: 1aa997bcda4258795ea9eee1430843928dc185fad40067b180593456057a9126  # [win64]
+    folder: msvc  # [win64]
+  - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-pc-windows-msvc.tar.gz  # [win and arm64]
+    sha256: d9ad7d70dc50f366464071f1676d7caa80a54c00b487883ce1eca372cb96a387  # [win and arm64]
+    folder: msvc  # [win and arm64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-gnu.tar.gz  # [win64]
-    sha256: 8637789a8690bc964a21d99b5dafcbc4f660460a445c11f492ebb788e60c7f67  # [win64]
-    folder: gnu  # [win]
+    sha256: 378e17f1fe2d3e9f62b4d38371068cda1cab9ea47c561af4ea326abfefd8874e  # [win64]
+    folder: gnu  # [win64]
     #### end of main rust toolchain sources
     #### start of rust-std-extra toolchain sources
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip1.tar.gz
-    sha256: 07c866640f550fec060e6b24992c339a20bba30f2cdedb780aceb35b1fbd49cf
+    sha256: 0ea19575b8fd5238e4e094bfb849df1d265a97c824ca6f31d607699588b3dffd
     folder: rust-std-wasm32-wasip1
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip2.tar.gz
-    sha256: d792c62f8f11e2676f34f89f72c87fe3a4c0f82d990ded171db753e1a661583c
+    sha256: f4405a408199bac5babba5f26ab967a61b19002ae8b75514874822b4b4fd1238
     folder: rust-std-wasm32-wasip2
     #### end of rust-std-extra toolchain sources
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: rust
@@ -82,7 +85,6 @@ outputs:
       build:
         - {{ stdlib('c') }}    # [osx]
         - {{ compiler('c') }}    # [osx]
-        - posix  # [win]
     test:
       requires:
         - {{ stdlib('c') }}
@@ -98,21 +100,18 @@ outputs:
         - rustdoc --help
         - time bash ./forge_test.sh  # [not win]
 
-  - name: rust-gnu  # [win]
-    script: install-gnu.bat  # [win]
-    build:  # [win]
+  - name: rust-gnu  # [win64]
+    script: install-gnu.bat  # [win64]
+    build:  # [win64]
       # the distributed binaries are already relocatable
-      binary_relocation: False  # [win]
-    requirements:  # [win]
-      build:  # [win]
-        - posix # [win]
-    test:  # [win]
-      commands:  # [win]
-        - rustc --version  # [win]
-        - cargo --help  # [win]
-        - rustc --help  # [win]
-        - rustdoc --help  # [win]
-        - if exist %LIBRARY_PREFIX%\share\doc\rust\html\sysroot exit 1  # [win]
+      binary_relocation: False  # [win64]
+    test:  # [win64]
+      commands:  # [win64]
+        - rustc --version  # [win64]
+        - cargo --help  # [win64]
+        - rustc --help  # [win64]
+        - rustdoc --help  # [win64]
+        - if exist %LIBRARY_PREFIX%\share\doc\rust\html\sysroot exit 1  # [win64]
 
   - name: rust-std-{{ rust_std_extra }}
     build:
@@ -131,9 +130,6 @@ outputs:
           - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
     script: install-rust-std-extra.bat  # [win]
-    requirements:
-      build:
-        - posix  # [win]
     test:
       commands:
         - echo ON  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,7 +89,6 @@ outputs:
       build:
         - {{ stdlib('c') }}    # [osx]
         - {{ compiler('c') }}    # [osx]
-        - msys2-posix  # [win]
     test:
       requires:
         - {{ stdlib('c') }}
@@ -110,9 +109,6 @@ outputs:
     build:  # [win]
       # the distributed binaries are already relocatable
       binary_relocation: False  # [win]
-    requirements:  # [win]
-      build:  # [win]
-        - msys2-posix # [win]
     test:  # [win]
       commands:  # [win]
         - rustc --version  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     #### end of rust-std-extra toolchain sources
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: rust
@@ -134,9 +134,6 @@ outputs:
           - {{ pin_subpackage("rust", exact=True) }}
     script: install-rust-std-extra.sh  # [unix]
     script: install-rust-std-extra.bat  # [win]
-    requirements:
-      build:
-        - msys2-posix  # [win]
     test:
       commands:
         - echo ON  # [win]


### PR DESCRIPTION
rust rebuild remove dependency on `msys2-posix`

[PKG-15367](https://anaconda.atlassian.net/browse/PKG-15367)

## Changes
- Replace `msys2-posix` + `bash install.sh` Windows install path with xcopy-based `install*.bat` scripts that install rustc components directly from the upstream tarballs.
- Strip docs and rust-installer metadata during install to reduce package size.
- Copy `libexec/` (rust-analyzer proc-macro server) for parity with main.
- Split Windows sources by arch (`[win and x86_64]` / `[win and arm64]`).
- Add win-arm64 toolchain sources:
  - `rust`: `aarch64-pc-windows-msvc`
  - `rust-gnu`: `aarch64-pc-windows-gnullvm`
- Change `rust-gnu` output selector from `[win64]` to `[win]`.
- Remove `msys2-posix` build dependencies.
- Bump build number to 1.

## Package summary

Validated PR artifacts from graph [`308115b2-709b-4c9f-a467-c2c4cf8b57f4`](https://package-build.anaconda.com/v1/graph/308115b2-709b-4c9f-a467-c2c4cf8b57f4) (`5a87935`) against `pkgs/main` win-64 rust **1.96.0** by extracting each `.conda` and comparing per-file SHA-256 hashes.

| Package | Main (`pkgs/main`) | This PR (graph `308115b2`) | Overlapping files | Changed | Only in main |
|---------|-------------------|---------------------------|-------------------|---------|--------------|
| `rust` | `hd7fb8db_0` | `hd7fb8db_1` | 154 | **0** | 51,997 (docs + installer metadata) |
| `rust-gnu` | `haa95532_0` | `haa95532_1` | 197 | **0** | 52,004 (docs + installer metadata) |
| `rust-std-wasm32-wasip1` | `h340d600_0` | `h340d600_1` | 57 | **0** | 0 |
| `rust-std-wasm32-wasip2` | `h8c166ce_0` | `h8c166ce_1` | 59 | **0** | 0 |

**Every file present in both packages is byte-identical.** The only files in main but not in this PR are documentation (`Library/share/doc/`, ~52k files) and rust-installer metadata (`components`, `manifest-*`, `install.log`, etc.) — intentionally stripped by the install scripts.

[PKG-15367]: https://anaconda.atlassian.net/browse/PKG-15367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ