### PR TITLE
PKG-12506: rust 1.93.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ source:
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
     sha256: 08656839d486c823ea8ff59fc61aa7a7eae6600fa38fa7d9b426544cb7761eaf  # [win]
     folder: msvc  # [win]
-  - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-gnu.tar.gz  # [win64]
-    sha256: 38a90e59750595bfceaa62f65d791032554bf5d1bc3ebe4fd83fe2140967d9f9  # [win64]
+  - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-gnu.tar.gz  # [win]
+    sha256: 38a90e59750595bfceaa62f65d791032554bf5d1bc3ebe4fd83fe2140967d9f9  # [win]
     folder: gnu  # [win]
     #### end of main rust toolchain sources
     #### start of rust-std-extra toolchain sources

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # !! update of rust version should be carried out together with rust-activation version update !!
 # https://github.com/AnacondaRecipes/rust-activation-feedstock
-{% set version = "1.90.0" %}
+{% set version = "1.93.1" %}
 
 package:
   name: 'rust-suite'
@@ -9,24 +9,24 @@ package:
 source:
     #### start of main rust toolchain sources
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux64]
-    sha256: e453bae1c68d02fe2eae065c5452d5731308164cd154154c6ee442d2fa590685  # [linux64]
+    sha256: fa99eb4e823fdeb8ee25e486c7973b4803013ac68c64e8f74880da788db9739c  # [linux64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
-    sha256: 293f412e3412c3aa3398c78ebbdf898fa08eacad80c85a7332ce1a455504c5fc  # [aarch64]
+    sha256: bbe822f0aae2c1d31fa950a78446d4749e07ed67e974f87bf0c69146df2a9d9c  # [aarch64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
-    sha256: a11b52e34f5e80cb25d49f7943ae60e0b069b431727a4c09b2c890ceebee3687  # [osx and arm64]
+    sha256: 6bafa3b5367019c576751741295e06717f8f28c9d0e6631dcb9496cd142a386a  # [osx and arm64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win]
-    sha256: 1aa997bcda4258795ea9eee1430843928dc185fad40067b180593456057a9126  # [win]
+    sha256: 08656839d486c823ea8ff59fc61aa7a7eae6600fa38fa7d9b426544cb7761eaf  # [win]
     folder: msvc  # [win]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-gnu.tar.gz  # [win64]
-    sha256: 378e17f1fe2d3e9f62b4d38371068cda1cab9ea47c561af4ea326abfefd8874e  # [win64]
+    sha256: 38a90e59750595bfceaa62f65d791032554bf5d1bc3ebe4fd83fe2140967d9f9  # [win64]
     folder: gnu  # [win]
     #### end of main rust toolchain sources
     #### start of rust-std-extra toolchain sources
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip1.tar.gz
-    sha256: 0ea19575b8fd5238e4e094bfb849df1d265a97c824ca6f31d607699588b3dffd
+    sha256: 929efd30f18cccf998c29d90a2696fae3dd206baf1469bc0db0b19ad0190311a
     folder: rust-std-wasm32-wasip1
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-wasip2.tar.gz
-    sha256: f4405a408199bac5babba5f26ab967a61b19002ae8b75514874822b4b4fd1238
+    sha256: 9b1babecacd6e8ed7d37dfb825a00b4536b213d521ee9e1237f67c9ac82cec6b
     folder: rust-std-wasm32-wasip2
     #### end of rust-std-extra toolchain sources
 


### PR DESCRIPTION
rust 1.90

Destination channel: defaults

Links
[PKG-12506](https://anaconda.atlassian.net/browse/PKG-12506)
[Upstream repository](https://github.com/rust-lang/rust/tree/1.93.1)
Explanation of changes:

- new version number

[PKG-12506]: https://anaconda.atlassian.net/browse/PKG-12506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ