### PR TITLE
PKG-14085: drop rust_win-32 from anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -11,4 +11,3 @@ upstream_sources:
       - rust-gnu
       - rust-std-wasm32-wasip1
       - rust-std-wasm32-wasip2
-      - rust_win-32


### PR DESCRIPTION
## Summary
Remove `rust_win-32` from `upstream_sources.packages`. Follow-up: update `slo_curated.csv` row ~3863 in aggregate checkout.

## Ticket
PKG-14085

Made with [Cursor](https://cursor.com)